### PR TITLE
replaced wording 'client' with 'server' for UDP

### DIFF
--- a/smartpower3/wifimanager.cpp
+++ b/smartpower3/wifimanager.cpp
@@ -11,8 +11,8 @@ const char *MSG_CMD_CONNECT_INFO = ">>> AP connection info <<<";
 const char *MSG_CMD_NO_CONNECT = ">>> AP no connnection <<<";
 const char *MSG_CMD_SET_UDP = ">>> Setting UDP <<<";
 const char *MSG_CMD = "Command : ";
-const char *MSG_CMD_UDP_INFO = ">>> UDP client connection info for logging <<<";
-const char *MSG_CMD_NO_UDP_INFO = ">>> No UDP client info <<<";
+const char *MSG_CMD_UDP_INFO = ">>> UDP server connection info for logging <<<";
+const char *MSG_CMD_NO_UDP_INFO = ">>> No UDP server info <<<";
 
 const char *encryption_str(int encryption)
 {
@@ -278,7 +278,7 @@ void WiFiManager::ap_select(int ap_list_cnt)
     }
 }
 
-void WiFiManager::udp_client_info()
+void WiFiManager::udp_server_info()
 {
     Serial.printf("IP Address [%s]\n\r", ipaddr_udp.toString().c_str());
     Serial.printf("Port [%d]\n\r", port_udp);
@@ -312,7 +312,7 @@ void WiFiManager::set_udp()
     Serial.println("*                                                *");
 	Serial.println("**************************************************");
 
-	Serial.println("Input your IP address of UDP client ex) 192.168.0.5:");
+	Serial.println("Input your IP address of UDP server ex) 192.168.0.5:");
 
     memset(ipaddr, 0x00, sizeof(ipaddr));
 	memset(port, 0x00, sizeof(port));
@@ -330,7 +330,7 @@ void WiFiManager::set_udp()
 						Serial.printf("IP address set ok: ");
 						Serial.println(ipaddr_udp.toString());
 						NVS.setString("ipaddr_udp", ipaddr);
-						Serial.printf("\n\rInput your port number of UDP client ex) 6000:\n\r");
+						Serial.printf("\n\rInput your port number of UDP server ex) 6000:\n\r");
 						idx = 1;
 						pos = 0;
 					} else {
@@ -370,14 +370,14 @@ void WiFiManager::set_udp()
 			if (idx == 0) {
 				if (pos > 15) {
 					Serial.printf("Wrong IP address.\n\r");
-					Serial.println("Input your IP address of UDP client ex) 192.168.0.5:");
+					Serial.println("Input your IP address of UDP server ex) 192.168.0.5:");
 					pos = 0;
 					memset(ipaddr, 0x00, sizeof(ipaddr));
 				}
 			} else {
 				if (pos > 4) {
 					Serial.printf("Wrong port number.\n\r");
-					Serial.println("Input your port number of UDP client ex) 6000:");
+					Serial.println("Input your port number of UDP server ex) 6000:");
 					pos = 0;
 					memset(port, 0x00, sizeof(port));
 				}
@@ -402,7 +402,7 @@ void WiFiManager::cmd_main(char idata)
         break;
         case    '2':
 			Serial.printf("%s\n\r", MSG_CMD_UDP_INFO);
-			udp_client_info();
+			udp_server_info();
         break;
         case    '3':
             ap_scanning();

--- a/smartpower3/wifimanager.h
+++ b/smartpower3/wifimanager.h
@@ -37,9 +37,9 @@ const char *TestSendData = "0123456789012345678901234567890123456789012345678901
 const char WIFI_CMD_MENU[][50] = {
     "[ WIFI Command mode menu ]",
     "1. Connection AP Info",
-    "2. Connection UDP client Info",
+    "2. Connection UDP server Info",
     "3. Scan & Connection AP",
-    "4. Set IP address of UDP client for data logging",
+    "4. Set IP address of UDP server for data logging",
     "5. WiFi Command mode exit"
 };
 
@@ -58,7 +58,7 @@ public:
 	void ap_set_passwd(int ap_number);
 	void ap_select(int ap_list_cnt);
 	void ap_info(int ap_number);
-	void udp_client_info();
+	void udp_server_info();
 	void cmd_main(char idata);
 	bool isCommandMode(void);
 	void setCommandMode(void);


### PR DESCRIPTION
This commit does not change any logic, it just replaces "client" with "server" in respect to UDP, e.g.

    >>> WiFi command mode entered <<<

    [ WIFI Command mode menu ]
    1. Connection AP Info
    2. Connection UDP server Info
    3. Scan & Connection AP
    4. Set IP address of UDP server for data logging
    5. WiFi Command mode exit
    Command : 4
    >>> Setting UDP <<<
    **************************************************
    *                                                *
    *           For exit press [Ctrl+c]...           *
    *                                                *
    **************************************************
    Input your IP address of UDP server ex) 192.168.0.5:

Of course this also needs changes to the wiki.