### PR TITLE
add option -D/--duration for time-limited loggging

### DIFF
--- a/contrib/Readme.md
+++ b/contrib/Readme.md
@@ -13,8 +13,7 @@ UDP-logging uses pure python3, serial-logging requires pyserial.
 
 Feedback from Windows-users would be appreciated!
 
-UDP-logging requires a post 1.8 firmware. The master-branch has all the
-necessary patches, but currently you have to compile your own firmware.
+UDP-logging requires a post 1.8 firmware.
 
 The script will not only capture the data, but allows also to add a
 timestamp (iso-format,unix-format,whatever) as an additional column.


### PR DESCRIPTION
Hi,

this patch adds a new option to sp3-datalogger.py. The new option allows to limit the logging to a fixed duration (starting from the first valid sample).

It also removes the now obsolete comment about the need to build your own firmware.