### PR TITLE
experimental encoder settings

### DIFF
--- a/smartpower3/inputmanager.cpp
+++ b/smartpower3/inputmanager.cpp
@@ -38,9 +38,9 @@ uint8_t Button::checkPressed(void) {
 void initEncoder(void *dial)
 {
 	ESP32Encoder::useInternalWeakPullResistors = UP;
-	encoder.attachHalfQuad(33, 32);
+	encoder.attachFullQuad(33, 32);
 	encoder.setCount(0);
-	encoder.setFilter(500);
+	encoder.setFilter(1023);
 	xTaskCreate(countEncoder, "encoderTask", 1500, dial, 1, NULL);
 }
 
@@ -50,26 +50,34 @@ void countEncoder(void *dial)
 	int8_t cnt;
 	for (;;) {
 		cnt = encoder.getCount();
-		if (cnt > 5) {
+		if (cnt > 9) {
 			encoder.setCount(0);
 			tmp->cnt += 1;
 			tmp->direct = 1;
-			tmp->step = 10;
-		} else if (cnt < -5) {
+			tmp->step = 3;
+			vTaskDelay(5);
+			continue;
+		} else if (cnt < -9) {
 			encoder.setCount(0);
 			tmp->cnt -= 1;
 			tmp->direct = -1;
-			tmp->step = 10;
+			tmp->step = 3;
+			vTaskDelay(5);
+			continue;
 		} else if (cnt > 1) {
 			encoder.setCount(0);
 			tmp->cnt += 1;
 			tmp->direct = 1;
 			tmp->step = 1;
+			vTaskDelay(55);
+			continue;
 		} else if (cnt < -1) {
 			encoder.setCount(0);
 			tmp->cnt -= 1;
 			tmp->direct = -1;
 			tmp->step = 1;
+			vTaskDelay(55);
+			continue;
 		}
 		vTaskDelay(100);
 	}

--- a/smartpower3/smartpower3.ino
+++ b/smartpower3/smartpower3.ino
@@ -24,13 +24,13 @@ void setup(void) {
 	I2CB.begin(21, 22, (uint32_t)800000);
 	PAC.begin(&I2CB);
 	screen.begin(&I2CA);
-	initEncoder(&dial);
+	initEncoder(&dial);  // this also starts a task, without specified core
 
-	xTaskCreatePinnedToCore(screenTask, "Draw Screen", 6000, NULL, 1, NULL, 1);
-	xTaskCreatePinnedToCore(wifiTask, "WiFi Task", 5000, NULL, 1, NULL, 1);
-	xTaskCreatePinnedToCore(logTask, "Log Task", 8000, NULL, 1, NULL, 1);
-	xTaskCreate(inputTask, "Input Task", 8000, NULL, 1, NULL);
-	xTaskCreate(btnTask, "Button Task", 4000, NULL, 1, NULL);
+	xTaskCreatePinnedToCore(screenTask, "Draw Screen", 6000, NULL, 1, NULL, 1);  // delay 10
+	xTaskCreatePinnedToCore(wifiTask, "WiFi Task", 5000, NULL, 1, NULL, 1);  // delay 50
+	xTaskCreatePinnedToCore(logTask, "Log Task", 8000, NULL, 1, NULL, 1);  // delay 10, 250 or 1 depending on logging interval and interrupt count
+	xTaskCreate(inputTask, "Input Task", 8000, NULL, 1, NULL);  // delay 10, also counts for screen
+	xTaskCreate(btnTask, "Button Task", 4000, NULL, 1, NULL);  // delay 10
 
 	pinMode(25, INPUT_PULLUP);
 	pinMode(26, INPUT_PULLUP);


### PR DESCRIPTION
Experimental encoder settings - the encoder works at every step and the turning results are reasonably predictable at normal turning speed.

It's a compromise of personal preferences and hardware resources usage.

More comments at bug description (https://github.com/hardkernel/smartpower3/issues/4).