### PR TITLE
fix output voltage selection allowing unusable steps

### DIFF
--- a/smartpower3/channel.h
+++ b/smartpower3/channel.h
@@ -101,4 +101,5 @@ private:
 	uint16_t low_volt = 0;
 	uint8_t count_intr[8] = {0,};
 	uint8_t flag_clear_debug = 0;
+	uint16_t countVolt(float volt_set);
 };

--- a/smartpower3/helpers.cpp
+++ b/smartpower3/helpers.cpp
@@ -17,3 +17,21 @@ void clampVariableToCircularRange(int lower_limit, int upper_limit, int8_t direc
 		}
 	}
 }
+
+void clampVoltageDialCountToRange(uint16_t current_volt_set, int16_t *dial_count) {
+	int16_t absolute_low_limit = 3000;
+	int16_t absolute_high_limit = 20000;
+	int16_t step_change_voltage = 11000;
+	int8_t lower_limit, upper_limit = 0;
+	int8_t all_steps_count = 125;
+
+	if (current_volt_set >= step_change_voltage) {
+		upper_limit = (absolute_high_limit-current_volt_set)/200;
+		lower_limit = upper_limit-all_steps_count;
+	} else {
+		lower_limit = -(current_volt_set-absolute_low_limit)/100;
+		upper_limit = (all_steps_count+lower_limit);  // lower limit has negative value or is 0
+	}
+
+	clampVariableToRange(lower_limit, upper_limit, dial_count);
+}

--- a/smartpower3/helpers.h
+++ b/smartpower3/helpers.h
@@ -8,6 +8,7 @@
 
 template<typename I, typename S> void clampVariableToRange(I, I, S*);
 void clampVariableToCircularRange(int lower_limit, int upper_limit, int8_t direction, int16_t *variable_to_clamp);
+void clampVoltageDialCountToRange(uint16_t current_volt_set, int16_t *dial_count);
 
 
 /*

--- a/smartpower3/screen.cpp
+++ b/smartpower3/screen.cpp
@@ -638,9 +638,9 @@ void Screen::drawScreen()
 void Screen::changeVolt(screen_mode_t mode)
 {
 	if (selected == STATE_VOLT0) {
-		clampVariableToRange(-(volt_set/100 - 30), (200 - (volt_set/100)), &dial_cnt);
+		clampVoltageDialCountToRange(volt_set, &dial_cnt);
 		if (mode == BASE_MOVE) {
-			channel[0]->setVolt(dial_cnt); // this by default sets incremental difference to currently set value
+			channel[0]->setVolt(dial_cnt);  // this by default sets incremental difference to currently set value
 			if (dial_cnt != 0) {
 				NVS.setString("voltage0", String(channel[0]->getVolt()/1000.0));
 
@@ -651,7 +651,7 @@ void Screen::changeVolt(screen_mode_t mode)
 	} else if (selected == STATE_CURRENT0) {
 		clampVariableToRange(-(current_limit - 5), (30 - current_limit), &dial_cnt);
 		if (mode == BASE_MOVE) {
-			channel[0]->setCurrentLimit(dial_cnt);  // this by default sets absolute value
+			channel[0]->setCurrentLimit(dial_cnt); // this by default sets incremental difference to currently set value
 			if (dial_cnt != 0) {
 				NVS.setString("current_limit0", String(channel[0]->getCurrentLimit()/10.0));
 			}
@@ -660,9 +660,9 @@ void Screen::changeVolt(screen_mode_t mode)
 		}
 
 	} else if (selected == STATE_VOLT1) {
-		clampVariableToRange(-(volt_set/100 - 30), (200 - (volt_set/100)), &dial_cnt);
+		clampVoltageDialCountToRange(volt_set, &dial_cnt);
 		if (mode == BASE_MOVE) {
-			channel[1]->setVolt(dial_cnt); // this by default sets incremental difference to currently set value
+			channel[1]->setVolt(dial_cnt);  // this by default sets incremental difference to currently set value
 			if (dial_cnt != 0) {
 				NVS.setString("voltage1", String(channel[1]->getVolt()/1000.0));
 			}
@@ -672,7 +672,7 @@ void Screen::changeVolt(screen_mode_t mode)
 	} else if (selected == STATE_CURRENT1) {
 		clampVariableToRange(-(current_limit - 5), (30 - current_limit), &dial_cnt);
 		if (mode == BASE_MOVE) {
-			channel[1]->setCurrentLimit(dial_cnt);  // this by default sets absolute value
+			channel[1]->setCurrentLimit(dial_cnt); // this by default sets incremental difference to currently set value
 			if (dial_cnt != 0) {
 				NVS.setString("current_limit1", String(channel[1]->getCurrentLimit()/10.0));
 			}


### PR DESCRIPTION
Should fix https://github.com/hardkernel/smartpower3/issues/31 - the problem, where above 11V, it was possible to select output voltage by 100mV increments when the output chip allows only 200mV steps.