### PR TITLE
Add the ability to enable/disable a channel over WiFi

### DIFF
--- a/smartpower3/screenmanager.cpp
+++ b/smartpower3/screenmanager.cpp
@@ -84,6 +84,35 @@ void ScreenManager::pushInputPower(uint16_t volt, uint16_t ampere, uint16_t watt
 	header->pushPower(volt, ampere, watt);
 }
 
+void ScreenManager::enableChannel(uint8_t idx)
+{
+	if (idx != 0 && idx != 1)
+		return;
+
+	if (onoff[idx] == 0)
+		onoff[idx] = 3;
+}
+
+void ScreenManager::disableChannel(uint8_t idx)
+{
+	if (idx != 0 && idx != 1)
+		return;
+
+	if (onoff[idx] == 1)
+		onoff[idx] = 2;
+}
+
+void ScreenManager::toggleChannel(uint8_t idx)
+{
+	if (idx != 0 && idx != 1)
+		return;
+
+	if (onoff[idx] == 1)
+		onoff[idx] = 2;
+	else if (onoff[idx] == 0)
+		onoff[idx] = 3;
+}
+
 void ScreenManager::checkOnOff()
 {
 	if (state_power == 1) {
@@ -315,10 +344,7 @@ void ScreenManager::getBtnPress(uint8_t idx, uint32_t cur_time, bool long_presse
 	case 1:  // Channel1 ON/OFF
 		if (shutdown || screen != VOLTAGE_SCREEN || long_pressed)
 			break;
-		if (onoff[idx] == 1)
-			onoff[idx] = 2;
-		else if (onoff[idx] == 0)
-			onoff[idx] = 3;
+		toggleChannel(idx);
 		btn_pressed[idx] = true;
 		break;
 	case 2:  // MENU/CANCEL

--- a/smartpower3/screenmanager.h
+++ b/smartpower3/screenmanager.h
@@ -29,6 +29,9 @@ public:
 	void pushPower(uint16_t volt, uint16_t ampere, uint16_t watt, uint8_t ch);
 	void pushInputPower(uint16_t volt, uint16_t ampere, uint16_t watt);
 	void disablePower();
+	void enableChannel(uint8_t idx);
+	void disableChannel(uint8_t idx);
+	void toggleChannel(uint8_t idx);
 	uint8_t* getOnOff(void);
 	void checkOnOff();
 	void debug();

--- a/smartpower3/settings.cpp
+++ b/smartpower3/settings.cpp
@@ -46,6 +46,8 @@ void Settings::init()
 	//IPAddress wifi_ipv4_address_dns_2;
 	this->wifi_ipv4_udp_logging_server_ip_address = this->getWifiIpv4UdpLoggingServerIpAddress(true);
 	this->wifi_ipv4_udp_logging_server_port = this->getWifiIpv4UdpLoggingServerPort(true);
+	this->wifiPowerToggling = this->isWifiPowerTogglingEnabled(true);
+	this->wifiPowerTogglingAnyIP = this->canWifiPowerToggleFromAnyIP(true);
 	// Various
 	this->first_boot = this->isFirstBoot(true);
 	this->wifi_credentials_state = this->getWifiCredentialsState(true);
@@ -320,6 +322,28 @@ void Settings::setWifiUseIpv6 (bool wifiUseIpv6)
 {
 	wifi_use_ipv6 = wifiUseIpv6;
 }*/
+
+bool Settings::isWifiPowerTogglingEnabled (bool from_storage)
+{
+	return from_storage ? preferences.getBool("wifi_pwr_tgl", false) : wifiPowerToggling;
+}
+
+void Settings::setWifiPowerTogglingEnabled (bool enabled)
+{
+	preferences.putBool("wifi_pwr_tgl", enabled);
+	wifiPowerToggling = enabled;
+}
+
+bool Settings::canWifiPowerToggleFromAnyIP (bool from_storage)
+{
+	return from_storage ? preferences.getBool("wifi_pwr_anyip", false) : wifiPowerTogglingAnyIP;
+}
+
+void Settings::setCanWifiPowerToggleFromAnyIP (bool allowAnyIP)
+{
+	preferences.putBool("wifi_pwr_anyip", allowAnyIP);
+	wifiPowerTogglingAnyIP = allowAnyIP;
+}
 
 bool Settings::isFirstBoot(bool from_storage)
 {

--- a/smartpower3/settings.h
+++ b/smartpower3/settings.h
@@ -67,6 +67,10 @@ public:
 	void setWifiUseIpv4 (bool wifiUseIpv4 = true);
 	bool isWifiUseIpv6 () const;
 	void setWifiUseIpv6 (bool wifiUseIpv6 = false);
+	bool isWifiPowerTogglingEnabled(bool from_storage = false);
+	void setWifiPowerTogglingEnabled(bool enabled);
+	bool canWifiPowerToggleFromAnyIP(bool from_storage = false);
+	void setCanWifiPowerToggleFromAnyIP(bool allowAnyIP);
 	bool isFirstBoot(bool from_storage = false);
 	void setFirstBoot(bool firstBoot = false, bool force_commit = true);
 	wifi_credentials_state_e getWifiCredentialsState(bool from_storage = false);
@@ -117,6 +121,8 @@ private:
 	IPAddress wifi_ipv4_address_dns_2;*/
 	IPAddress wifi_ipv4_udp_logging_server_ip_address = IPAddress(0,0,0,0);
 	uint16_t wifi_ipv4_udp_logging_server_port = 0;
+	bool wifiPowerToggling;
+	bool wifiPowerTogglingAnyIP;
 	Preferences preferences;
 	bool nvs_cleared = false;
 };

--- a/smartpower3/smartpower3.ino
+++ b/smartpower3/smartpower3.ino
@@ -144,7 +144,9 @@ void inputTask(void *parameter)
 void wifiTask(void *parameter)
 {
 	for (;;) {
-		if (wifi_manager->canConnect() && wifi_manager->isWiFiEnabled()) {
+		if (wifi_manager->isConnected()) {
+			wifi_manager->parseWiFiPacket(screen_manager);
+		} else if (wifi_manager->canConnect() && wifi_manager->isWiFiEnabled()) {
 			wifi_manager->apConnectFromSettings();
 		} else if (!wifi_manager->isWiFiEnabled()) {
 			wifi_manager->apDisconnectAndTurnWiFiOff();

--- a/smartpower3/wifimanager.h
+++ b/smartpower3/wifimanager.h
@@ -34,8 +34,11 @@ const char wifi_cmd_menu[][50] = {
 	"6. Forget UDP server IP address",
 	"7. (Dis)Connect WiFi connection",
 	"8. Switch logging ON or OFF",
-	"9. WiFi Command mode exit"
+	"9. Allow toggling channel power via WiFi",
+	"A. WiFi Command mode exit"
 };
+
+class ScreenManager;
 
 class WiFiManager
 {
@@ -70,11 +73,13 @@ public:
 	void switchWifiState(bool from_storage);
 	void setUdp();
 	void switchLoggingOnOff(void);
+	void switchPowerToggling(void);
 	uint16_t port_udp = 0;
 	IPAddress ipaddr_udp;
 	bool update_udp_info = true;
 	bool update_wifi_info = true;
 	void runWiFiLogging(const char *buf0, const char *buf1, const char *buf2, const char *buf3);
+	void parseWiFiPacket(ScreenManager &screen_manager);
 private:
 	WiFiUDP udp;
 	WiFiClient client;


### PR DESCRIPTION
Currently the only way to enable or disable a channel's power is by pressing a button. It can be useful to be able to do it via Wifi.

For the ability to work, the user needs to configure it via serial command line. There, it can be:
* allowed from any IP address,
* allowed from IP address of the logging server,
* forbidden.

To enable or disable a channel's power via WiFi, an UDP packet containing an 8 bytes long message (`enblChnN` or `dsblChnN`) must be sent to the SmartPower3 device IP address, UDP port 3333.

This can be done for example with the socat utility:
```
echo -n enblChn0 | socat stdin udp-sendto:IP_ADDRESS:3333
```

The ability to toggle a channel's power can be useful for:
* Remote debugging. My SmartPower3 is at my office, powering devices that I am working on. I am developing U-Boot / Linux kernel drivers on these devices. Sometimes I need to disable the power for the device completely. Another plus is that when I am done working, I want to disable the power to the device completely, for safety.
* Automatic testing / CI. For example the U-Boot bootloader is actively developed, there are many changes being merged every week and these changes need to be automatically tested. Some devices need to be completely powered off/on to enter a mode that allows to upload firmware via serial. Having the ability to automatically power cycle a device is therefore helpful for automatic testing.